### PR TITLE
feat: Implement Admin Panel with Category CRUD

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="flex h-screen bg-gray-100 dark:bg-gray-900">
+    <!-- Sidebar -->
+    <aside class="w-64 flex-shrink-0 bg-white dark:bg-gray-800 border-r dark:border-gray-700">
+      <div class="h-full flex flex-col">
+        <div class="px-4 py-6">
+          <h2 class="text-2xl font-semibold text-gray-800 dark:text-white">Admin Panel</h2>
+        </div>
+        <nav class="flex-1 px-2 py-4 space-y-2">
+          <NuxtLink
+            to="/admin"
+            class="flex items-center px-4 py-2 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700"
+            exact-active-class="bg-gray-300 dark:bg-gray-700"
+          >
+            <span class="mx-4">ダッシュボード</span>
+          </NuxtLink>
+          <NuxtLink
+            to="/admin/categories"
+            class="flex items-center px-4 py-2 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700"
+            exact-active-class="bg-gray-300 dark:bg-gray-700"
+          >
+            <span class="mx-4">カテゴリ管理</span>
+          </NuxtLink>
+          <NuxtLink
+            to="/admin/tags"
+            class="flex items-center px-4 py-2 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700"
+            exact-active-class="bg-gray-300 dark:bg-gray-700"
+          >
+            <span class="mx-4">タグ管理</span>
+          </NuxtLink>
+        </nav>
+      </div>
+    </aside>
+
+    <!-- Main content -->
+    <main class="flex-1 p-6 overflow-y-auto">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped>
+/* Scoped styles for the admin layout */
+</style>

--- a/middleware/admin.ts
+++ b/middleware/admin.ts
@@ -1,0 +1,15 @@
+export default defineNuxtRouteMiddleware(async (to, from) => {
+  const user = useSupabaseUser()
+
+  // Wait for user to be fetched
+  if (!user.value) {
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+
+  const isAdmin = user.value?.app_metadata?.claims_admin === true
+
+  if (!isAdmin) {
+    console.log('User is not an admin, redirecting.')
+    return navigateTo('/')
+  }
+})

--- a/pages/admin/categories.vue
+++ b/pages/admin/categories.vue
@@ -1,0 +1,165 @@
+<template>
+  <div>
+    <h1 class="text-3xl font-bold mb-6">カテゴリ管理</h1>
+
+    <!-- New Category Form -->
+    <div class="mb-8 p-4 bg-white dark:bg-gray-800 rounded-lg shadow">
+      <h2 class="text-xl font-semibold mb-4">新規カテゴリ作成</h2>
+      <form @submit.prevent="handleCreateCategory">
+        <div class="flex items-center gap-4">
+          <Input
+            v-model="newCategoryName"
+            placeholder="カテゴリ名"
+            required
+            class="flex-grow"
+          />
+          <Button type="submit" :disabled="loading">
+            {{ loading ? '作成中...' : '作成' }}
+          </Button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Categories Table -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+      <table class="min-w-full">
+        <thead class="bg-gray-50 dark:bg-gray-700">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">ID</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">名前</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">作成日時</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">アクション</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 dark:divide-gray-600">
+          <tr v-if="!categories || categories.length === 0">
+            <td colspan="4" class="px-6 py-4 text-center text-gray-500 dark:text-gray-400">カテゴリが見つかりません。</td>
+          </tr>
+          <tr v-for="category in categories" :key="category.id">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ category.id }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ category.name }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ new Date(category.created_at).toLocaleString() }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+              <Button variant="outline" size="sm" @click="openEditModal(category)">編集</Button>
+              <Button variant="destructive" size="sm" @click="handleDeleteCategory(category.id)">削除</Button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Edit Modal -->
+    <div v-if="isEditModalOpen" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 w-full max-w-md">
+        <h2 class="text-xl font-semibold mb-4">カテゴリを編集</h2>
+        <form @submit.prevent="handleUpdateCategory">
+          <div class="space-y-4">
+            <Input
+              v-model="editingCategoryName"
+              placeholder="カテゴリ名"
+              required
+            />
+            <div class="flex justify-end gap-4">
+              <Button type="button" variant="ghost" @click="closeEditModal">キャンセル</Button>
+              <Button type="submit" :disabled="loading">
+                {{ loading ? '更新中...' : '更新' }}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Database } from '~/types/supabase';
+import type { Category } from '~/types/product';
+
+definePageMeta({
+  layout: 'admin',
+  middleware: 'admin',
+})
+
+const supabase = useSupabaseClient<Database>()
+const { showToast } = useAlert()
+const loading = ref(false)
+
+// Fetch categories
+const { data: categories, refresh } = await useAsyncData('categories', async () => {
+  const { data, error } = await supabase.from('categories').select('*').order('created_at', { ascending: false })
+  if (error) throw error
+  return data
+})
+
+// Create
+const newCategoryName = ref('')
+const handleCreateCategory = async () => {
+  if (!newCategoryName.value.trim()) return
+  loading.value = true
+  try {
+    const { error } = await supabase.from('categories').insert({ name: newCategoryName.value.trim() })
+    if (error) throw error
+    showToast({ title: '成功', description: 'カテゴリが作成されました。' })
+    newCategoryName.value = ''
+    await refresh()
+  } catch (error: any) {
+    showToast({ title: 'エラー', description: error.message, variant: 'destructive' })
+  } finally {
+    loading.value = false
+  }
+}
+
+// Edit Modal
+const isEditModalOpen = ref(false)
+const editingCategory = ref<Category | null>(null)
+const editingCategoryName = ref('')
+
+const openEditModal = (category: Category) => {
+  editingCategory.value = category
+  editingCategoryName.value = category.name
+  isEditModalOpen.value = true
+}
+
+const closeEditModal = () => {
+  isEditModalOpen.value = false
+  editingCategory.value = null
+  editingCategoryName.value = ''
+}
+
+// Update
+const handleUpdateCategory = async () => {
+  if (!editingCategory.value || !editingCategoryName.value.trim()) return
+  loading.value = true
+  try {
+    const { error } = await supabase
+      .from('categories')
+      .update({ name: editingCategoryName.value.trim() })
+      .eq('id', editingCategory.value.id)
+    if (error) throw error
+    showToast({ title: '成功', description: 'カテゴリが更新されました。' })
+    closeEditModal()
+    await refresh()
+  } catch (error: any) {
+    showToast({ title: 'エラー', description: error.message, variant: 'destructive' })
+  } finally {
+    loading.value = false
+  }
+}
+
+// Delete
+const handleDeleteCategory = async (id: number) => {
+  if (!confirm('本当にこのカテゴリを削除しますか？')) return
+  loading.value = true
+  try {
+    const { error } = await supabase.from('categories').delete().eq('id', id)
+    if (error) throw error
+    showToast({ title: '成功', description: 'カテゴリが削除されました。' })
+    await refresh()
+  } catch (error: any) {
+    showToast({ title: 'エラー', description: error.message, variant: 'destructive' })
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <h1 class="text-3xl font-bold mb-6">ようこそ、管理者パネルへ</h1>
+    <p class="text-lg">左のメニューから操作を選択してください。</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  layout: 'admin',
+  middleware: 'admin',
+})
+</script>

--- a/supabase/migrations/20250905075700_add_rls_policies_for_admin.sql
+++ b/supabase/migrations/20250905075700_add_rls_policies_for_admin.sql
@@ -1,0 +1,49 @@
+-- Drop existing RLS policies for categories and tags
+DROP POLICY IF EXISTS "Categories are publicly viewable." ON public.categories;
+DROP POLICY IF EXISTS "Authenticated users can insert categories." ON public.categories;
+DROP POLICY IF EXISTS "Authenticated users can update categories." ON public.categories;
+DROP POLICY IF EXISTS "Authenticated users can delete categories." ON public.categories; -- In case a delete policy exists
+
+DROP POLICY IF EXISTS "Tags are publicly viewable." ON public.tags;
+DROP POLICY IF EXISTS "Authenticated users can insert tags." ON public.tags;
+DROP POLICY IF EXISTS "Authenticated users can update tags." ON public.tags;
+DROP POLICY IF EXISTS "Authenticated users can delete tags." ON public.tags; -- In case a delete policy exists
+
+-- Helper function to check for admin claims from JWT
+-- This function extracts the 'claims_admin' custom claim from the JWT.
+create or replace function public.is_claims_admin()
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select coalesce((auth.jwt() -> 'raw_app_meta_data' ->> 'claims_admin')::boolean, false)
+$$;
+
+-- Add new RLS policies for categories
+-- 1. Admin full access
+CREATE POLICY "Admin full access on categories"
+ON public.categories
+FOR ALL
+USING (public.is_claims_admin())
+WITH CHECK (public.is_claims_admin());
+
+-- 2. Public read access
+CREATE POLICY "Public can read categories"
+ON public.categories
+FOR SELECT
+USING (true);
+
+-- Add new RLS policies for tags
+-- 1. Admin full access
+CREATE POLICY "Admin full access on tags"
+ON public.tags
+FOR ALL
+USING (public.is_claims_admin())
+WITH CHECK (public.is_claims_admin());
+
+-- 2. Public read access
+CREATE POLICY "Public can read tags"
+ON public.tags
+FOR SELECT
+USING (true);

--- a/types/product.ts
+++ b/types/product.ts
@@ -23,3 +23,15 @@ export interface ProductWithRelations extends Product {
     name: string;
   }[];
 }
+
+export interface Category {
+  id: number;
+  name: string;
+  created_at: string;
+}
+
+export interface Tag {
+  id: number;
+  name: string;
+  created_at: string;
+}


### PR DESCRIPTION
This commit introduces the initial version of the admin panel.

- Sets up RLS policies to grant full access to admin users (`claims_admin: true`) and read-only access to the public for categories and tags.
- Creates a dedicated admin layout with sidebar navigation.
- Implements an admin middleware to protect routes under `/admin`.
- Adds an admin dashboard page.
- Implements a full CRUD interface for managing categories on the `/admin/categories` page, including creation, listing, editing (via modal), and deletion.